### PR TITLE
Added length selection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2803,7 +2803,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -3168,7 +3169,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -3216,6 +3218,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -3254,11 +3257,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         },
@@ -6940,7 +6945,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -6958,11 +6964,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -6975,15 +6983,18 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -7086,7 +7097,8 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -7096,6 +7108,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -7108,17 +7121,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -7135,6 +7151,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -7207,7 +7224,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -7217,6 +7235,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -7292,7 +7311,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -7322,6 +7342,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -7339,6 +7360,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -7377,11 +7399,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         }

--- a/src/PasswordGenerator/index.js
+++ b/src/PasswordGenerator/index.js
@@ -14,10 +14,37 @@ class PasswordGenerator extends React.Component {
 
     setPasswordState = (password) => this.setState({ generatedPassword: password });
 
-    generateNewPassword() {
+    pairEquals = (length)=>{
+        //get all numbers less than length
+        let prevNums = [];
+        let targetLen = length - 1
+        for(let i = 1; i< targetLen; i++) {prevNums.push(i)};
+        //find numbers that can be added to get targetLen 
+        let final = [];
+        function subsetSum(numbers, target, partial) {
+        var s, n, remaining;
+        partial = partial || [];
+        // sum partial
+        s = partial.reduce(function (a, b) { return a + b; }, 0);
+        // check if the partial sum is equals to target
+        if (s === target && partial.length === 2 && !partial.includes(2) && !partial.includes(1) ) {
+             final.push([...partial]);  
+            }
+        if (s >= target) return;  
+        for (var i = 0; i < numbers.length; i++) {
+            n = numbers[i];
+            remaining = numbers.slice(i + 1);
+            subsetSum(remaining, target, partial.concat([n]));
+        }
+        }
+        subsetSum(prevNums,targetLen);
+        return final
+    }
+
+    generateNewPassword = (length) =>{
         let adjectives, nouns = [];
         const req = new XMLHttpRequest();
-
+        console.log(length)
         req.open('GET',  window.location + 'data/en_adjectives.txt', false);
         req.send(null);
         if (req.status === 200)
@@ -27,14 +54,18 @@ class PasswordGenerator extends React.Component {
         req.send(null);
         if (req.status === 200)
             nouns = req.responseText.split(/\r?\n|\r/);
-
-
-        const rand1 = Math.floor((Math.random() * adjectives.length) + 1);
-        const rand2 = Math.floor((Math.random() * nouns.length) + 1);
-        const adjective = adjectives[rand1];
-        const noun = nouns[rand2];
-
-        this.setPasswordState(adjective + "%" + noun);
+        //get pairs of numbers that add up to length -1 (I use length-1 instead of length because % is counted in final length)
+        const pairs = this.pairEquals(length);
+        //randomly choose one of the permutations.
+        const chosenPair = pairs[Math.floor(Math.random()*pairs.length) ];
+        //Extract array of words with appropriate lengths that match pair
+        let adjectivesWithLength = adjectives.filter(item=>{return item.length === chosenPair[1] });
+        let nounsWithLength = nouns.filter(item=>{return item.length === chosenPair[0] });
+        //get random indexes from get random index from above arrays
+        const rand1 = Math.floor((Math.random() * adjectivesWithLength.length) );
+        const rand2 = Math.floor((Math.random() * nounsWithLength.length) );
+        
+        this.setPasswordState(adjectivesWithLength[rand1]+ "%" + nounsWithLength[rand2])
     }
 
     render() {

--- a/src/PasswordGenerator/view.js
+++ b/src/PasswordGenerator/view.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Row, Col, Button } from 'react-materialize';
+import { Row, Col, Button, Range } from 'react-materialize';
 
 const PasswordGeneratorView = (props) => {
     const {
@@ -7,6 +7,7 @@ const PasswordGeneratorView = (props) => {
         handler
     } = props;
 
+  const range= React.createRef();
     return (
         <div>
             <Row>
@@ -14,7 +15,15 @@ const PasswordGeneratorView = (props) => {
                     <p id="#your-password">{text}</p>
                 </Col>
                 <Col s={12}>
-                <Button waves="light" style={{marginRight: '5px'}} onClick={handler}>
+                    <p> Password length:</p>
+                    <Range ref={range} max="20" min="10"/>
+                </Col>
+                <Col s={12}>
+                <Button waves="light" style={{marginRight: '5px'}} onClick={()=>{
+                    console.log(range.current._range.value)
+                    handler(range.current._range.value)
+                    
+                    }}>
                     Generate
                 </Button>
                 </Col>


### PR DESCRIPTION
I added the ability to select password lengths. The main issue I encountered was that some adjectives and nouns of specific lengths do not exist (2 and 1 letter words to be specific). 

Logic:
- After subtracting 1 from the length (The 1 character represents the %)
- Get all possible permutations of adjectives and noun lengths to make up the length
- Randomly select one of those and get filter the list of adjectives and nouns according to those lengths
- Using that array, generate a random index for the final adjective and noun.
- Concatenate them with a % separator.

I hope this makes sense. If it needs work let me know.